### PR TITLE
Use appearance change listener for theme provider

### DIFF
--- a/src/providers/ThemeProvider/index.tsx
+++ b/src/providers/ThemeProvider/index.tsx
@@ -11,12 +11,17 @@ export const ThemeContext = createContext({
 })
 
 export const ThemeProvider: FC<any> = (props: any) => {
-  const colorScheme = Appearance.getColorScheme()
-  const [isDark, setIsDark] = useState(colorScheme === 'dark')
+  const [isDark, setIsDark] = useState(Appearance.getColorScheme() === 'dark')
 
   useEffect(() => {
-    setIsDark(colorScheme === 'dark')
-  }, [colorScheme])
+    const subscription = Appearance.addChangeListener(({colorScheme}) => {
+      setIsDark(colorScheme === 'dark')
+    })
+
+    return () => {
+      subscription.remove()
+    }
+  }, [])
 
   const defaultTheme = {
     isDark,


### PR DESCRIPTION
## Summary
- listen to color scheme changes in `ThemeProvider`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68423a0289b4832db31e95c7c4d643f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved theme switching to respond instantly to system color scheme changes. The app now updates its appearance automatically when your device switches between light and dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->