### PR TITLE
Fix SQL parameterization in category/entry models

### DIFF
--- a/src/utils/database/categoryModel.ts
+++ b/src/utils/database/categoryModel.ts
@@ -121,7 +121,8 @@ export const getIncomeCategoriesQuery = async () => {
 export const getGoalsCategoriesQuery = async (type: any) => {
   try {
     const categories: any = await selectQuery(
-      `SELECT * FROM categories WHERE type = "${type}"`,
+      'SELECT * FROM categories WHERE type = ?',
+      [type],
     )
     return categories.raw()
   } catch (error) {

--- a/src/utils/database/entryModel.ts
+++ b/src/utils/database/entryModel.ts
@@ -860,7 +860,8 @@ export function* getEntriesGoalsQuery(
 
     const entries: any = yield call(
       selectQuery,
-      `${query} WHERE entries.payment_type = "${type}" AND entries.category_id IS NULL ORDER BY entries.date DESC`,
+      `${query} WHERE entries.payment_type = ? AND entries.category_id IS NULL ORDER BY entries.date DESC`,
+      [type],
     )
     const queryEntries = entries.raw()
 


### PR DESCRIPTION
## Summary
- prevent SQL injection by parameterizing `type` in category & entry queries

## Testing
- `yarn install` *(fails: dependencies require build tools)*
- `yarn test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68423ded221c832dbc84a4d76187bc1a