### PR TITLE
Update account queries to group by ID

### DIFF
--- a/src/utils/database/accountModel.ts
+++ b/src/utils/database/accountModel.ts
@@ -87,7 +87,7 @@ export function* getAccountsQuery(
       THEN -entries.amount WHEN entries.entry_type = 'goals' \
       AND entries.payment_type = 'general' AND (NOT entries.status = 'pending' OR entries.status IS NULL)\
       THEN -entries.amount ELSE 0 END) as total_amount FROM accounts \
-      LEFT JOIN (SELECT id, name as currency_name, symbol as currency_symbol, decimal FROM currencies) cur ON cur.id = accounts.currency_id LEFT JOIN entries ON entries.account_id = accounts.id GROUP BY account_name",
+      LEFT JOIN (SELECT id, name as currency_name, symbol as currency_symbol, decimal FROM currencies) cur ON cur.id = accounts.currency_id LEFT JOIN entries ON entries.account_id = accounts.id GROUP BY accounts.id",
     )
 
     const rawAccounts = accounts.raw()
@@ -107,7 +107,7 @@ export function* getAccountsQuery(
         )
         const entries = yield call(
           getAccountEntriesQuery,
-          account?.account_name,
+          account?.id,
         )
 
         const currenciesAccount = entries.reduce((prev: any, next: any) => {
@@ -157,13 +157,13 @@ export function* getAccountQuery(
       AND entries.payment_type = 'general' AND (NOT entries.status = 'pending' OR entries.status IS NULL) \
       THEN -entries.amount WHEN entries.entry_type = 'goals' \
       AND entries.payment_type = 'general' AND (NOT entries.status = 'pending' OR entries.status IS NULL)\
-      THEN -entries.amount ELSE 0 END) as total_amount FROM accounts LEFT JOIN (SELECT id, name as currency_name, symbol as currency_symbol, decimal FROM currencies) cur ON cur.id = accounts.currency_id LEFT JOIN entries ON entries.account_id = accounts.id WHERE accounts.id = ? GROUP BY account_name",
+      THEN -entries.amount ELSE 0 END) as total_amount FROM accounts LEFT JOIN (SELECT id, name as currency_name, symbol as currency_symbol, decimal FROM currencies) cur ON cur.id = accounts.currency_id LEFT JOIN entries ON entries.account_id = accounts.id WHERE accounts.id = ? GROUP BY accounts.id",
       [id],
     )
 
     const account = accounts.raw()[0]
 
-    const entries = yield call(getAccountEntriesQuery, account?.account_name)
+    const entries = yield call(getAccountEntriesQuery, account?.id)
 
     account.entries = entries
     if (account?.account_type === 'wallet') {

--- a/src/utils/database/entryModel.ts
+++ b/src/utils/database/entryModel.ts
@@ -387,7 +387,7 @@ export const getAccountEntriesQuery = async (account: any) => {
     LEFT JOIN accounts ON accounts.id = entries.account_id\
     LEFT JOIN currencies ON currencies.id = accounts.currency_id\
     LEFT JOIN (SELECT id, payment_type as type FROM entries) as entry ON entries.entry_id = entry.id\
-    WHERE entries.payment_type = "general" AND accounts.account_name = ? ORDER BY entries.date DESC'
+    WHERE entries.payment_type = "general" AND entries.account_id = ? ORDER BY entries.date DESC'
 
     const entries: any = await selectQuery(`${query} `, [account])
     return entries.raw()


### PR DESCRIPTION
## Summary
- group account aggregates by account ID
- fetch account entries by ID instead of name

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684240cb207c832d9affe724d0be5e63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of account and entry retrieval by grouping and filtering using unique account IDs instead of account names. This enhances consistency when displaying accounts and their related entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->