### PR TITLE
Enable foreign keys and cleanup deletes

### DIFF
--- a/src/store/account/saga.ts
+++ b/src/store/account/saga.ts
@@ -43,7 +43,6 @@ import {
   createAccountQuery,
   createEntryQuery,
   createOrUpdateCurrencyQuery,
-  deleteAccountEntryQuery,
   deleteAccountQuery,
   deleteEntryQuery,
   getAccountQuery,
@@ -358,7 +357,6 @@ export function* updateAccountAsync({payload}: any): any {
 
 export function* deleteSingleAccountAsync({payload}: any): any {
   try {
-    yield call(deleteAccountEntryQuery, payload)
     yield call(deleteAccountQuery, payload)
 
     let {currencies} = yield select(selectCurrency)

--- a/src/utils/database/categoryModel.ts
+++ b/src/utils/database/categoryModel.ts
@@ -47,7 +47,6 @@ export const updateCategoryQuery = async (data: any, id: any) => {
 export const deleteCategoryQuery = async (id: any) => {
   try {
     await selectQuery('DELETE FROM categories WHERE id = ?', [id])
-    await selectQuery('DELETE FROM entries WHERE category_id = ?', [id])
     return true
   } catch (error) {
     debugLog('error deleting category', error)

--- a/src/utils/database/createTables.ts
+++ b/src/utils/database/createTables.ts
@@ -13,7 +13,7 @@ const createUserTable = async () => {
       picture VARCHAR, \
       language VARCHAR,\
       notification_token VARCHAR,\
-      FOREIGN KEY(currency_id) REFERENCES currencies(id)\
+      FOREIGN KEY(currency_id) REFERENCES currencies(id) ON DELETE CASCADE\
       )`)
     debugLog('user table created')
   } catch (error) {
@@ -83,8 +83,8 @@ const createAccountTable = async () => {
       account_type VARCHAR,\
       organization VARCHAR,\
       account_comments VARCHAR,\
-      FOREIGN KEY(user_id) REFERENCES users(id)\
-      FOREIGN KEY(currency_id) REFERENCES currencies(id)\
+      FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE\
+      FOREIGN KEY(currency_id) REFERENCES currencies(id) ON DELETE CASCADE\
       )`)
 
     debugLog('account table created')
@@ -129,9 +129,9 @@ const createEntriesTable = async () => {
       status_level VARCHAR,\
       date DATETIME,\
       limit_date DATETIME,\
-      FOREIGN KEY(account_id) REFERENCES accounts(id)
-      FOREIGN KEY(entry_id) REFERENCES entries(id)
-      FOREIGN KEY(category_id) REFERENCES categories(id)
+      FOREIGN KEY(account_id) REFERENCES accounts(id) ON DELETE CASCADE
+      FOREIGN KEY(entry_id) REFERENCES entries(id) ON DELETE CASCADE
+      FOREIGN KEY(category_id) REFERENCES categories(id) ON DELETE CASCADE
       )`)
     const data: any = await selectQuery('PRAGMA table_info(entries)')
     const tables = data?.raw()

--- a/src/utils/database/entryModel.ts
+++ b/src/utils/database/entryModel.ts
@@ -407,7 +407,6 @@ export const deleteAccountEntryQuery = async (id: any) => {
 export const deleteEntryQuery = async (id: any) => {
   try {
     await selectQuery('DELETE FROM entries WHERE id = ?', [id])
-    await selectQuery('DELETE FROM entries WHERE entry_id = ?', [id])
     return
   } catch (error) {
     debugLog('error deleting entry', error)

--- a/src/utils/database/init.ts
+++ b/src/utils/database/init.ts
@@ -5,6 +5,7 @@ const database = SQLite.openDatabase(
   {name: 'finami.db', location: 'default'},
   () => {
     debugLog('database connected')
+    database.executeSql('PRAGMA foreign_keys = ON')
   },
   (e: any) => {
     debugLog('database error', e)

--- a/src/utils/database/truncateTables.ts
+++ b/src/utils/database/truncateTables.ts
@@ -34,10 +34,12 @@ const TruncateCategoriesTable = async () => {
 
 const TruncateTables = async () => {
   try {
-    await TruncateEntriesTable()
-    await TruncateAccountsTable()
-    await TruncateUsersTable()
-    await TruncateCategoriesTable()
+    await database.transaction(async tx => {
+      await tx.executeSql('DELETE FROM entries')
+      await tx.executeSql('DELETE FROM accounts')
+      await tx.executeSql('DELETE FROM users')
+      await tx.executeSql('DELETE FROM categories')
+    })
   } catch (error) {
     debugLog(error, 'an error happend truncate tables')
   }


### PR DESCRIPTION
## Summary
- enable SQLite foreign keys on connection
- use cascading deletes in table definitions
- rely on cascades for entry & category deletion
- remove redundant delete in account saga
- wrap table truncation in a single transaction

## Testing
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6842dcdee868832d81ae9a70d7fd5e7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved database deletion behavior so that related records are now automatically removed when deleting currencies, users, accounts, entries, or categories.
- **Chores**
	- Enhanced database initialization to ensure foreign key constraints are always enforced.
	- Optimized table reset operations by performing deletions within a single transaction for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->